### PR TITLE
PEP8 Coding Style

### DIFF
--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -26,7 +26,8 @@ def luhn(s):
     return int(math.ceil(float(sum)/10) * 10 - float(sum))
 
 # testDate will test if date is valid or not.
-def testDate(year, month, day):
+def _test_date(year, month, day):
+    """
     for x in ['19', '20']:
         newy = x.__str__() + year.__str__()
         newy = int(newy)
@@ -40,7 +41,7 @@ def testDate(year, month, day):
     return False
 
 # valid will validate Swedish social security numbers.
-def valid(s, includeCoordinationNumber = True):
+def valid(s, include_coordination_number=True):
     if isinstance(s, string_types) is False and isinstance(s, numbers.Integral) is False:
         return False
 
@@ -63,10 +64,10 @@ def valid(s, includeCoordinationNumber = True):
 
     valid = luhn(year + month + day + num) == int(check)
 
-    if valid and testDate(year, int(month), int(day)):
+    if valid and _test_date(year, int(month), int(day)):
         return True
 
-    if not includeCoordinationNumber:
+    if not include_coordination_number:
         return False
 
-    return valid and testDate(year, int(month), int(day) - 60)
+    return valid and _test_date(year, int(month), int(day) - 60)

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -11,6 +11,7 @@ if PY3:
 else:
     string_types = basestring
 
+
 def luhn(s):
     """
     Test if the input string is a valid Luhn string.
@@ -29,6 +30,7 @@ def luhn(s):
 
     return int(math.ceil(float(sum)/10) * 10 - float(sum))
 
+
 def _test_date(year, month, day):
     """
     Test if the input parameters are a valid date or not
@@ -44,6 +46,7 @@ def _test_date(year, month, day):
             continue
 
     return False
+
 
 def valid(s, include_coordination_number=True):
     """

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -18,7 +18,6 @@ def luhn(s):
     :param s:
     :return:
     """
-    v = 0
     sum = 0
 
     for i in range(0, len(s)):

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -39,7 +39,7 @@ def _test_date(year, month, day):
         newy = int(newy)
         try:
             date = datetime.date(newy, month, day)
-            if (date.year != newy or date.month != month or date.day != day) == False:
+            if not (date.year != newy or date.month != month or date.day != day):
                 return True
         except ValueError:
             continue

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -11,8 +11,12 @@ if PY3:
 else:
     string_types = basestring
 
-# luhn will test if the given string is a valid luhn string.
 def luhn(s):
+    """
+    Test if the input string is a valid Luhn string.
+    :param s:
+    :return:
+    """
     v = 0
     sum = 0
 
@@ -25,8 +29,9 @@ def luhn(s):
 
     return int(math.ceil(float(sum)/10) * 10 - float(sum))
 
-# testDate will test if date is valid or not.
 def _test_date(year, month, day):
+    """
+    Test if the input parameters are a valid date or not
     """
     for x in ['19', '20']:
         newy = x.__str__() + year.__str__()
@@ -40,8 +45,18 @@ def _test_date(year, month, day):
 
     return False
 
-# valid will validate Swedish social security numbers.
 def valid(s, include_coordination_number=True):
+    """
+    Validate Swedish social security numbers
+
+    :param s: A Swedish social security number to validate
+    :param include_coordination_number: Set to False in order to exclude
+        coordination number (Samordningsnummer) from validation
+    :type s: str|int
+    :type include_coordination_number: bool
+    :rtype: bool
+    :return:
+    """
     if isinstance(s, string_types) is False and isinstance(s, numbers.Integral) is False:
         return False
 

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -62,7 +62,7 @@ def valid(s, include_coordination_number=True):
     if isinstance(s, string_types) is False and isinstance(s, numbers.Integral) is False:
         return False
 
-    reg = "^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$"
+    reg = r"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$"
     match = re.match(reg, s.__str__())
 
     if not match:

--- a/personnummer/tests/test_personnummer.py
+++ b/personnummer/tests/test_personnummer.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from personnummer import personnummer
 
+
 class TestPersonnummer(TestCase):
     def test_with_control_digit(self):
         self.assertTrue(personnummer.valid(6403273813))


### PR DESCRIPTION
This is a fix for #9 

- Rename `testDate` to `_test_date`
- Rename `includeCoordinationNumber` to `include_coordination_number`
- Set the regular expression variable `reg` as a raw string to remove warnings about invalid escape sequences
- Document functions and parameters in docstrings
- Remove an unused variable in the `luhn(s)` function