### PR TITLE
Use Ubuntu 14.04 in Travis for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.4
   - 3.5
   - 3.6
   - pypy
   - pypy3
+matrix:
+  include:
+    - python: 2.6
+      dist: trusty
 install:
   - pip install -U setuptools pip
   - python setup.py clean --all


### PR DESCRIPTION
The default OS was switched a while ago from Trusty (14.04) to Xenial (16.04) in Travis. And tests are [failing](https://travis-ci.org/personnummer/python/jobs/567254873) as Python 2.6 isn't supported in Xenial.

This PR makes tests for Python 2.6 run in Trusty again.

_Another option is to completely drop support for python 2.6. But I don't see a reason to since it can still work for now._