### PR TITLE
Allow formatting a Swedish SSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,32 @@ or
 pip3 install personnummer
 ```
 
-## Example
+## Examples
+
+### Validation
 
 ```python
 from personnummer import personnummer
 
 personnummer.valid("0001010107")
 # => True
+
+personnummer.valid("19130401+2931")
+# => True
+```
+
+### Format
+
+```python
+from personnummer import personnummer
+
+# Short format
+personnummer.format(6403273813)
+# => '640327-3813'
+
+# Long format
+personnummer.format('6403273813', True)
+# => '196403273813'
 ```
 
 See [personnummer/tests/test_personnummer.py](personnummer/tests/test_personnummer.py) for more examples.

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -14,8 +14,9 @@ else:
 
 def luhn(s):
     """
-    Test if the input string is a valid Luhn string.
+    Calculates the Luhn checksum of a string of digits
     :param s:
+    :type s: str
     :return:
     """
     sum = 0
@@ -47,9 +48,60 @@ def _test_date(year, month, day):
     return False
 
 
+def _get_parts(ssn):
+    """
+    Get different parts of a Swedish social security number
+    :param ssn: A Swedish social security number to format
+    :type ssn: str|int
+    :rtype: dict
+    :return: Returns a dictionary of the different parts of a Swedish SSN.
+        The dict keys are:
+        'century', 'year', 'month', 'day', 'sep', 'num', 'check'
+    """
+    reg = r"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$"
+    match = re.match(reg, str(ssn))
+
+    if not match:
+        raise ValueError(
+            'Could not parse "{}" as a valid Swedish SSN.'.format(ssn))
+
+    century = match.group(1)
+    year = match.group(2)
+    month = match.group(3)
+    day = match.group(4)
+    sep = match.group(5)
+    num = match.group(6)
+    check = match.group(7)
+
+    if sep == '':
+        if not century:
+            sep = '-'
+        elif datetime.datetime.now().year - int(century + year) < 100:
+            sep = '-'
+        else:
+            sep = '+'
+
+    if not century:
+        base_year = datetime.datetime.now().year
+        if sep == '+':
+            base_year = base_year - 100
+        full_year = base_year - ((base_year - int(year)) % 100)
+        century = str(int(full_year / 100))
+
+    return {
+        'century': century,
+        'year': year,
+        'month': month,
+        'day': day,
+        'sep': sep,
+        'num': num,
+        'check': check
+    }
+
+
 def valid(s, include_coordination_number=True):
     """
-    Validate Swedish social security numbers
+    Validate a Swedish social security number
 
     :param s: A Swedish social security number to validate
     :param include_coordination_number: Set to False in order to exclude
@@ -62,29 +114,58 @@ def valid(s, include_coordination_number=True):
     if isinstance(s, string_types) is False and isinstance(s, numbers.Integral) is False:
         return False
 
-    reg = r"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-|\+]{0,1})?(\d{3})(\d{0,1})$"
-    match = re.match(reg, s.__str__())
-
-    if not match:
+    try:
+        parts = _get_parts(s)
+    except ValueError:
         return False
 
-    century = match.group(1)
-    year    = match.group(2)
-    month   = match.group(3)
-    day     = match.group(4)
-    sep     = match.group(5)
-    num     = match.group(6)
-    check   = match.group(7)
+    year = parts['year']
+    month = parts['month']
+    day = parts['day']
+    num = parts['num']
+    check = parts['check']
 
     if len(check) == 0:
         return False
 
-    valid = luhn(year + month + day + num) == int(check)
+    is_valid = luhn(year + month + day + num) == int(check)
 
-    if valid and _test_date(year, int(month), int(day)):
+    if is_valid and _test_date(year, int(month), int(day)):
         return True
 
     if not include_coordination_number:
         return False
 
-    return valid and _test_date(year, int(month), int(day) - 60)
+    return is_valid and _test_date(year, int(month), int(day) - 60)
+
+
+def format(ssn, long_format=False):
+    """
+    Format a Swedish social security number as one of the official formats,
+    A long format or a short format.
+
+    This function raises a ValueError if the input number could not be parsed
+    as a valid Swedish social security number
+
+    :param ssn: A Swedish social security number to format
+    :param long_format: Defaults to False and formats a social security number
+        as YYMMDD-XXXX. If set to True the format will be YYYYMMDDXXXX.
+    :type ssn: str|int
+    :type long_format: bool
+    :rtype: str
+    :return:
+    """
+
+    if not valid(ssn):
+        raise ValueError(
+            'The social security number "{}" is not valid '
+            'and cannot be formatted.'.format(ssn)
+        )
+
+    if long_format:
+        ssn_format = '{century}{year}{month}{day}{num}{check}'
+    else:
+        ssn_format = '{year}{month}{day}{sep}{num}{check}'
+
+    parts = _get_parts(ssn)
+    return ssn_format.format(**parts)

--- a/personnummer/tests/test_personnummer.py
+++ b/personnummer/tests/test_personnummer.py
@@ -54,3 +54,22 @@ class TestPersonnummer(TestCase):
     def test_wrong_coordination_numbers(self):
         self.assertFalse(personnummer.valid('900161-0017'))
         self.assertFalse(personnummer.valid('640893-3231'))
+
+    def test_format(self):
+        self.assertEqual('640327-3813', personnummer.format(6403273813))
+        self.assertEqual('510818-9167', personnummer.format('510818-9167'))
+        self.assertEqual('900101-0017', personnummer.format('19900101-0017'))
+        self.assertEqual('130401+2931', personnummer.format('19130401+2931'))
+        self.assertEqual('640823-3234', personnummer.format('196408233234'))
+        self.assertEqual('000101-0107', personnummer.format('0001010107'))
+        self.assertEqual('000101-0107', personnummer.format('000101-0107'))
+        self.assertEqual('130401+2931', personnummer.format('191304012931'))
+        self.assertEqual('196403273813', personnummer.format(6403273813, True))
+        self.assertEqual('195108189167', personnummer.format('510818-9167', True))
+        self.assertEqual('199001010017', personnummer.format('19900101-0017', True))
+        self.assertEqual('191304012931', personnummer.format('19130401+2931', True))
+        self.assertEqual('196408233234', personnummer.format('196408233234', True))
+        self.assertEqual('200001010107', personnummer.format('0001010107', True))
+        self.assertEqual('200001010107', personnummer.format('000101-0107', True))
+        self.assertEqual('190001010107', personnummer.format('000101+0107', True))
+        self.assertRaises(ValueError, personnummer.format, "19990919_3766")


### PR DESCRIPTION
Fixes #7

This PR replaces #4 and it is rewritten so it matches what spec'ed in the [meta repository][meta-repo].

- I don't know where to find documentation regarding the + or - in the number. So I just migrated the code the PHP library. If there is a documentation for the behavior (preferably in English), I'd like to have a link so I can verify the code more properly.
- The [meta repository][meta-repo] doesn't define what is the expected behavior of trying to format an invalid value. So I raised a ValueError exception in that case. I believe it's better than having the function return 2 different objects.
- I used the same test cases that were used in the PHP library.
  _(Although I would recommend adding a list of inputs and their respective expected output in the meta library to document what needs to be tested as part of the spec.)_

_I cheated and also updated the description of the `luhn` and `valid` functions as part of this PR. I can remove them if you mind them being in this PR._

[meta-repo]: https://github.com/personnummer/meta