### PR TITLE
Add get_age function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ personnummer.format('6403273813', True)
 # => '196403273813'
 ```
 
+### Get Age
+```python
+from personnummer import personnummer
+
+personnummer.get_age(6403273813)
+# => 55
+```
+
 See [personnummer/tests/test_personnummer.py](personnummer/tests/test_personnummer.py) for more examples.
 
 ## License

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -12,6 +12,17 @@ else:
     string_types = basestring
 
 
+def _get_current_datetime():
+    """
+    Get current time. The purpose of this function is to be able to mock
+    current time during tests
+
+    :return:
+    :rtype datetime.datetime:
+    """
+    return datetime.datetime.now()
+
+
 def luhn(s):
     """
     Calculates the Luhn checksum of a string of digits
@@ -74,7 +85,7 @@ def _get_parts(ssn):
     check = match.group(7)
 
     if not century:
-        base_year = datetime.datetime.now().year
+        base_year = _get_current_datetime().year
         if sep == '+':
             base_year = base_year - 100
         else:
@@ -82,7 +93,7 @@ def _get_parts(ssn):
         full_year = base_year - ((base_year - int(year)) % 100)
         century = str(int(full_year / 100))
     else:
-        if datetime.datetime.now().year - int(century + year) < 100:
+        if _get_current_datetime().year - int(century + year) < 100:
             sep = '-'
         else:
             sep = '+'

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -200,7 +200,10 @@ def get_age(ssn, include_coordination_number=True):
     today = _get_current_datetime()
 
     parts = _get_parts(ssn)
-    year = int('{}{}'.format(parts['century'], parts['year']))
+    year = int('{century}{year}'.format(
+        century=parts['century'],
+        year=parts['year'])
+    )
     month = int(parts['month'])
     day = int(parts['day'])
     if include_coordination_number and day > 60:

--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -179,3 +179,31 @@ def format(ssn, long_format=False):
 
     parts = _get_parts(ssn)
     return ssn_format.format(**parts)
+
+
+def get_age(ssn, include_coordination_number=True):
+    """
+    Get the age of a person from a Swedish social security number
+
+    :param ssn: A Swedish social security number to format
+    :param include_coordination_number: Set to False in order to exclude
+        coordination number (Samordningsnummer) from being considered as valid
+    :type ssn: str|int
+    :rtype: int
+    :return:
+    """
+    if not valid(ssn, include_coordination_number=include_coordination_number):
+        raise ValueError(
+            'The social security number "{}" is not valid '
+            'and cannot extra the age from it.'.format(ssn)
+        )
+    today = _get_current_datetime()
+
+    parts = _get_parts(ssn)
+    year = int('{}{}'.format(parts['century'], parts['year']))
+    month = int(parts['month'])
+    day = int(parts['day'])
+    if include_coordination_number and day > 60:
+        day = day - 60
+
+    return today.year - year - ((today.month, today.day) < (month, day))

--- a/personnummer/tests/test_personnummer.py
+++ b/personnummer/tests/test_personnummer.py
@@ -73,3 +73,29 @@ class TestPersonnummer(TestCase):
         self.assertRaises(ValueError, personnummer.format, '199999999999')
         self.assertRaises(ValueError, personnummer.format, '199909193776')
         self.assertRaises(ValueError, personnummer.format, 'Just a string')
+
+    def test_get_age(self):
+        self.assertEqual(55, personnummer.get_age(6403273813))
+        self.assertEqual(67, personnummer.get_age('510818-9167'))
+        self.assertEqual(29, personnummer.get_age('19900101-0017'))
+        self.assertEqual(106, personnummer.get_age('19130401+2931'))
+        self.assertEqual(19, personnummer.get_age('200002296127'))
+
+    def test_get_age_with_coordination_number(self):
+        self.assertEqual(48, personnummer.get_age('701063-2391'))
+        self.assertEqual(54, personnummer.get_age('640883-3231'))
+        self.assertRaises(ValueError, personnummer.get_age, '701063-2391', False)
+
+    def test_get_age_with_invalid_numbers(self):
+        self.assertRaises(ValueError, personnummer.get_age, None)
+        self.assertRaises(ValueError, personnummer.get_age, [])
+        self.assertRaises(ValueError, personnummer.get_age, {})
+        self.assertRaises(ValueError, personnummer.get_age, False)
+        self.assertRaises(ValueError, personnummer.get_age, True)
+        self.assertRaises(ValueError, personnummer.get_age, 0)
+        self.assertRaises(ValueError, personnummer.get_age, '19112233-4455')
+        self.assertRaises(ValueError, personnummer.get_age, '20112233-4455')
+        self.assertRaises(ValueError, personnummer.get_age, '9999999999')
+        self.assertRaises(ValueError, personnummer.get_age, '199999999999')
+        self.assertRaises(ValueError, personnummer.get_age, '199909193776')
+        self.assertRaises(ValueError, personnummer.get_age, 'Just a string')

--- a/personnummer/tests/test_personnummer.py
+++ b/personnummer/tests/test_personnummer.py
@@ -1,8 +1,16 @@
+from datetime import datetime
 from unittest import TestCase
+
+import mock
+
 from personnummer import personnummer
 
 
+@mock.patch(
+    'personnummer.personnummer._get_current_datetime',
+    mock.Mock(return_value=datetime.fromtimestamp(1565704890)))
 class TestPersonnummer(TestCase):
+
     def test_with_control_digit(self):
         self.assertTrue(personnummer.valid(8507099805))
         self.assertTrue(personnummer.valid('198507099805'))
@@ -51,3 +59,17 @@ class TestPersonnummer(TestCase):
     def test_format_right_separator(self):
         self.assertEqual('850709-9805', personnummer.format('19850709+9805'))
         self.assertEqual('121212+1212', personnummer.format('19121212-1212'))
+
+    def test_format_with_invalid_numbers(self):
+        self.assertRaises(ValueError, personnummer.format, None)
+        self.assertRaises(ValueError, personnummer.format, [])
+        self.assertRaises(ValueError, personnummer.format, {})
+        self.assertRaises(ValueError, personnummer.format, False)
+        self.assertRaises(ValueError, personnummer.format, True)
+        self.assertRaises(ValueError, personnummer.format, 0)
+        self.assertRaises(ValueError, personnummer.format, '19112233-4455')
+        self.assertRaises(ValueError, personnummer.format, '20112233-4455')
+        self.assertRaises(ValueError, personnummer.format, '9999999999')
+        self.assertRaises(ValueError, personnummer.format, '199999999999')
+        self.assertRaises(ValueError, personnummer.format, '199909193776')
+        self.assertRaises(ValueError, personnummer.format, 'Just a string')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 
-setup(name='personnummer',
+setup(
+      name='personnummer',
       version='1.0.2',
       description='Validate Swedish social security numbers',
       url='http://github.com/personnummer/python',
@@ -9,5 +10,5 @@ setup(name='personnummer',
       license='MIT',
       packages=['personnummer'],
       test_suite='nose.collector',
-      tests_require=['nose'],
+      tests_require=['nose', 'mock'],
 )


### PR DESCRIPTION
Closes #8 
- Added the `get_age` function that takes a Swedish SSN as a required parameter and a second optional boolean parameter named `include_coordination_number` (defaults to `True`).
- Included the `mock` library as a dependency for tests in order to mock the current date which is needed for testing the `get_age` function
- Re-introduced tests for the format function when passing invalid inputs. I used the ones that were kept in the `test_wrong_personnummer_or_types` function in the [111bbde](https://github.com/personnummer/python/commit/111bbde78344cfc1b4fe8517251bc713d9fbdc54) commit.
- For testing the `get_age` function, I used the same values used in the PHP library.

If some values should be omitted or changed in the tests according to #14, let me know which ones. I wouldn't mind updating the PR.

_I strongly recommend documenting the values that need to be tested in the Meta package since this appears to be an issue._