### PR TITLE
Fix validation of personal numbers (years 2000-2009)

### DIFF
--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -211,7 +211,7 @@ def test_date(year, month, day):
     Test if the input parameters are a valid date or not
     """
     for x in ['19', '20']:
-        new_y = x.__str__() + year.__str__()
+        new_y = x.__str__() + year.__str__().zfill(2)
         new_y = int(new_y)
         try:
             date = datetime.date(new_y, month, day)


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Pad least significant digits in a `year` variable with zero. Fixes case when
`year < 10` (e.g. year == 0 would have produced `new_y` 190 and 200
instead of 1900 and 2000) leading to failed validation of some of
personal numbers  for people born in years 2000-2009.

**Related issue**

None.

**Motivation**

Fixes significant bug in validating of personal numbers (e.g. personal numbers of people born in years 2000-2009 may be affected).

**Checklist**

- [ ] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.
