### PR TITLE
Validate leap year dates correctly

### DIFF
--- a/personnummer/personnummer.py
+++ b/personnummer/personnummer.py
@@ -23,6 +23,7 @@ class Personnummer:
             options = {}
 
         self.options = options
+        self._ssn = ssn
         self.parts = self.get_parts(ssn)
 
         if self.valid() is False:
@@ -80,7 +81,11 @@ class Personnummer:
         return int(gender_digit) % 2 != 0
 
     def is_coordination_number(self):
-        return test_date(int(self.parts['year']), int(self.parts['month']), int(self.parts['day']) - 60)
+        return test_date(
+            int(self.parts['century'] + self.parts['year']),
+            int(self.parts['month']),
+            int(self.parts['day']) - 60,
+        )
 
     @staticmethod
     def get_parts(ssn):
@@ -133,6 +138,7 @@ class Personnummer:
         :return:
         """
 
+        century = self.parts['century']
         year = self.parts['year']
         month = self.parts['month']
         day = self.parts['day']
@@ -144,10 +150,10 @@ class Personnummer:
 
         is_valid = luhn(year + month + day + num) == int(check)
 
-        if is_valid and test_date(int(year), int(month), int(day)):
+        if is_valid and test_date(int(century + year), int(month), int(day)):
             return True
 
-        return is_valid and test_date(int(year), int(month), int(day) - 60)
+        return is_valid and test_date(int(century + year), int(month), int(day) - 60)
 
 
 def luhn(data):
@@ -210,14 +216,8 @@ def test_date(year, month, day):
     """
     Test if the input parameters are a valid date or not
     """
-    for x in ['19', '20']:
-        new_y = x.__str__() + year.__str__()
-        new_y = int(new_y)
-        try:
-            date = datetime.date(new_y, month, day)
-            if date.year == new_y and date.month == month and date.day == day:
-                return True
-        except ValueError:
-            continue
-
-    return False
+    try:
+        date = datetime.date(year, month, day)
+        return date.year == year and date.month == month and date.day == day
+    except ValueError:
+        return False


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Date validation is resulting in false negatives and positives for some people born on Feb-29 on a leap year. For example, `200002292399` is incorrectly failing validation:
```
>>> personnummer.Personnummer('200002292399').valid()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/site-packages/personnummer/personnummer.py", line 29, in __init__
    raise PersonnummerException(
personnummer.personnummer.PersonnummerException: 200002292399 Not a valid Swedish personal identity number!
```

**Related issue**
Replaces #46 

**Motivation**

Allow people born on leap years to use services relying on this package :see_no_evil: 

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [ ] Tests passes.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
- [ ] New tests added which covers the added code.

PS. I would like to add the `200002292399`  SSN to the list of test data here: https://github.com/personnummer/meta/blob/master/testdata/list.json

However, when running the `generateTestdata.php` script it's generating different SSNs and I'm not sure how is your contribution flow for those test. I could use some help adding it. :sweat_smile: 