### PR TITLE
Test suite

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,6 +28,6 @@ jobs:
         pip install -U setuptools
     - name: Run tests
       run: |
-        python setup.py clean --all
-        python setup.py install
-        python -W all setup.py test
+        pip install .[dev]
+        pytest
+        python -m build

--- a/personnummer/tests/test_personnummer.py
+++ b/personnummer/tests/test_personnummer.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from unittest import TestCase
+from unittest import mock
+
 from personnummer import personnummer
 import urllib.request
 import json
-import mock
 
 
 def get_test_data():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ version = "3.1.0"
 name = "personnummer"
 description = "Validate Swedish personal identity numbers"
 license = { file = "./LICENSE" }
+readme = "README.md"
 authors = [
     { name = "Personnummer and Contributors", email = "hello@personnummer.dev" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=61.2", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+version = "3.0.6"
+name = "personnummer"
+description = "Validate Swedish personal identity numbers"
+license = { file = "./LICENSE" }
+authors = [
+    { name = "Personnummer and Contributors", email = "hello@personnummer.dev" },
+]
+
+[project.urls]
+homepage = "https://personnummer.dev"
+repository = "https://github.com/personnummer/python"
+
+[project.entry-points."console_scripts"]
+personnummer = "personnummer.main:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "build",
+]
+
+[options]
+packages = ["personnummer"]
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+exclude = ["personnummer/tests*"]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "personnummer/tests",
+]
+addopts = "-ra -v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "3.0.6"
+version = "3.1.0"
 name = "personnummer"
 description = "Validate Swedish personal identity numbers"
 license = { file = "./LICENSE" }

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,4 @@
-from setuptools import setup
+import setuptools
 
-setup(
-    name='personnummer',
-    version='3.0.6',
-    description='Validate Swedish personal identity numbers',
-    url='http://github.com/personnummer/python',
-    author='Personnummer and Contributors',
-    author_email='hello@personnummer.dev',
-    license='MIT',
-    packages=['personnummer'],
-    test_suite='pytest',
-    tests_require=['pytest'],
-    entry_points={
-        'console_scripts': ['personnummer = personnummer.main:main']
-    },
-)
+if __name__ == "__main__":
+    setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     author_email='hello@personnummer.dev',
     license='MIT',
     packages=['personnummer'],
-    test_suite='nose.collector',
-    tests_require=['nose', 'mock'],
+    test_suite='pytest',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': ['personnummer = personnummer.main:main']
     },


### PR DESCRIPTION
**Type of change**

- [x] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**
Replace how the package is tested and built by replacing some obsolete functionality.

- Currently, it uses `nose` for testing, which is deprecated and discontinued in newer Python versions.
  This PR switches `nose` with `pytest`.
- The external `mock` package is not needed anymore as it is part of the builtins now.
- Building and testing with `setup.py` has been deprecated.
  This PR migrates from `setup.py` to use `pyproject.toml`.
- Bumped the version to 3.1.0

P.S. I have no experience with deploying to PyPi, so I kept `setup.py` as a shim. If you still use `setup.py` you need to make sure to use a newer version of setuptools. However, I can see in `publish.sh` that you use `python -m build`. If that's how it's done, the build will prioritize `pyproject.toml`.

**Related issue**
_N/A_

**Motivation**
The previous setup did not allow testing with newer Python versions. And I would like it to have official support for Python3.10+.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Style lints passes.
- [ ] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
<!-- - [ ] New tests added which covers the added code. -->
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->
