### PR TITLE
Follow the v3 specs

### DIFF
--- a/personnummer/tests/test_personnummer.py
+++ b/personnummer/tests/test_personnummer.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from unittest import TestCase
 from unittest import mock
 
@@ -26,62 +26,88 @@ availableListFormats = [
 class TestPersonnummer(TestCase):
     def testPersonnummerList(self):
         for item in test_data:
-            for format in availableListFormats:
+            for available_format in availableListFormats:
                 self.assertEqual(personnummer.valid(
-                    item[format]), item['valid'])
+                    item[available_format]), item['valid'])
 
     def testPersonnummerFormat(self):
         for item in test_data:
             if not item['valid']:
-                return
+                continue
 
-            for format in availableListFormats:
-                if format != 'short_format':
-                    self.assertEqual(personnummer.parse(
-                        item[format]).format(), item['separated_format'])
-                    self.assertEqual(personnummer.parse(
-                        item[format]).format(True), item['long_format'])
+            expected_long_format = item['long_format']
+            expected_separated_format: str = item['separated_format']
+            for available_format in availableListFormats:
+                if available_format == 'short_format' and '+' in expected_separated_format:
+                    # Since the short format is missing the separator,
+                    # the library will never use the `+` separator
+                    # in the outputted format
+                    continue
+                self.assertEqual(
+                    expected_separated_format,
+                    personnummer.parse(item[available_format]).format()
+                )
+                self.assertEqual(
+                    expected_long_format,
+                    personnummer.parse(item[available_format]).format(True)
+                )
 
     def testPersonnummerError(self):
         for item in test_data:
             if item['valid']:
-                return
+                continue
 
-            for format in availableListFormats:
-                try:
-                    personnummer.parse(item[format])
-                    self.assertTrue(False)
-                except:
-                    self.assertTrue(True)
+            for available_format in availableListFormats:
+                self.assertRaises(
+                    personnummer.PersonnummerException,
+                    personnummer.parse,
+                    item[available_format],
+                )
 
     def testPersonnummerSex(self):
         for item in test_data:
             if not item['valid']:
-                return
+                continue
 
-            for format in availableListFormats:
+            for available_format in availableListFormats:
                 self.assertEqual(personnummer.parse(
-                    item[format]).isMale(), item['isMale'])
+                    item[available_format]).is_male(), item['isMale'])
                 self.assertEqual(personnummer.parse(
-                    item[format]).isFemale(), item['isFemale'])
+                    item[available_format]).is_female(), item['isFemale'])
 
     def testPersonnummerAge(self):
         for item in test_data:
             if not item['valid']:
-                return
+                continue
 
-            for format in availableListFormats:
-                if format != 'short_format':
-                    pin = item['separated_long']
-                    year = int(pin[0:4])
-                    month = int(pin[4:6])
-                    day = int(pin[6:8])
+            separated_format = item['separated_format']
+            pin = item['separated_long']
+            year = int(pin[0:4])
+            month = int(pin[4:6])
+            day = int(pin[6:8])
 
-                    if item['type'] == 'con':
-                        day -= 60
+            if item['type'] == 'con':
+                day -= 60
+            if '+' in separated_format:
+                # This is needed in order for the age to be the same
+                # when testing the 'long_format' and any of the separated_*
+                # formats. Otherwise, the long format will have an age of 0
+                # and the separated ones will have an age of 100.
+                year += 100
 
-                    date = datetime(year=year, month=month, day=day)
-                    p = personnummer.parse(item[format])
-
-                    with mock.patch('personnummer.personnummer.get_current_datetime', mock.Mock(return_value=date)):
+            mocked_date = date(year=year, month=month, day=day)
+            for available_format in availableListFormats:
+                if available_format == 'short_format' and '+' in separated_format:
+                    # Since the short format is missing the separator,
+                    # the library will never use the `+` separator
+                    # in the outputted format
+                    continue
+                p = personnummer.parse(item[available_format])
+                with mock.patch(
+                    'personnummer.personnummer._get_current_date',
+                    mock.Mock(return_value=mocked_date)
+                ):
+                    if '+' in separated_format:
+                        self.assertEqual(100, p.get_age())
+                    else:
                         self.assertEqual(0, p.get_age())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "3.1.0"
+version = "3.2.0"
 name = "personnummer"
 description = "Validate Swedish personal identity numbers"
 license = { file = "./LICENSE" }


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

A bit of rewriting of the package, mainly.

- Most of the tests were not running at all, as the functions were breaking out of the test method when the ssn was invalid, which is the case starting from the first time in the [list of ssns](https://raw.githubusercontent.com/personnummer/meta/master/testdata/list.json).
- Made the package align more with the v3 versions and implemented the `get_date` method from v3.1.
- It is still missing the Interim-Number functionality, but I have to increase the minor version as it has some breaking changes of undocumented functionality, which should not be used outside of the library (next point).
- I prepended several methods with an underscore (`_`) that are not part of the meta documentation. These are somewhat annoying as IDE will show them in their auto-completion functionality. Having the underscore indicates that a method is only intended for internal use, [as defined by PEP8](https://peps.python.org/pep-0008/#descriptive-naming-styles).

**Missing functionality**
- More functionality needs to be tested, such as the `is_coordination_number()` method and the new `get_age()` method. But the PR was getting bigger and bigger and the tests were not working I decided to stop there and those can be done in a different PR.
- Parsing Interim-Number

**Related issue**

N/A

**Motivation**

Tests were not working.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests pass.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
- [ ] New tests added which covers the added code.
- [ ] Documentation is updated.
- [x] This PR includes breaking changes (but only undocumented functionality).
