### PR TITLE
Use classifiers to specify license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 authors = [
     { name = "Personnummer and Contributors", email = "hello@personnummer.dev" },
 ]
+classifiers = [
+	"License :: OSI Approved :: MIT License",
+]
 
 [project.urls]
 homepage = "https://personnummer.dev"


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

When this repo moved to using `pyproject.toml` it intoduced a bug for libraries like [pip-licenses](https://github.com/raimon49/pip-licenses) to properly determine the licese of this project. Since the file used to determine the license: `license = { file = "./LICENSE" }` is not standard due to extra text in front of the `Copyright` block

To fix this issue we can use [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) to set the license for the package.

**Motivation**

This pr fixes issues for others using [pip-licenses](https://github.com/raimon49/pip-licenses) to check for licenses in their dependencies

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [ ] Tests passes.
- [ ] Style lints passes.
- [ ] Documentation of new public methods exists.