### PR TITLE
Run tests on 22.04

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,9 +1,12 @@
-name: test
+name: Run tests
 
 on:
   push:
     branches:
       - master
+
+  # Allow running workflow manually
+  workflow_dispatch:
 
   # Run tests for any PRs.
   pull_request:


### PR DESCRIPTION
Tests are breaking on 24.04 (https://github.com/personnummer/python/actions/runs/12318663147) as the new version does not supports Python 3.7.

Switching to 22.04 for now and probably drop support for 3.7 in a future update.

news: https://github.com/actions/runner-images/issues/10636